### PR TITLE
Garden index crop display update

### DIFF
--- a/app/models/bed.rb
+++ b/app/models/bed.rb
@@ -5,4 +5,8 @@ class Bed < ApplicationRecord
   validates :description, presence: true
   validates :length, presence: true, numericality: { greater_than: 0 }
   validates :width, presence: true, numericality: { greater_than: 0 }
+
+  def planted_crops
+    return crops.where(planted: true)
+  end
 end

--- a/app/views/gardens/_garden.html.erb
+++ b/app/views/gardens/_garden.html.erb
@@ -35,10 +35,28 @@
             <div class="card plot-bed">
               <div class="card-body">
                 <div class="d-flex flex-wrap justify-content-around">
-                  <%# ------------- Plot crop emojis in bed ------------- %>
-                  <% bed.crops.each do |crop| %>
-                    <% if crop.planted? %>
+                  <%# ------------- Plot crop emojis in bed (max 12) ------------- %>
+                  <% bed.planted_crops.first(12).each do |crop| %>
+
+                    <%# ------------- If less that 4 crops in bed ------------- %>
+                    <% if bed.planted_crops.length <= 4 %>
                       <% 3.times do %>
+                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %>">
+                          <%= crop.emoji %>
+                        </h2>
+                      <% end %>
+
+                    <%# ------------- If 5-6 crops in bed ------------- %>
+                    <% elsif bed.planted_crops.length <= 6 %>
+                      <% 2.times do %>
+                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %>">
+                          <%= crop.emoji %>
+                        </h2>
+                      <% end %>
+
+                    <%# ------------- If more than 6 crops in bed ------------- %>
+                    <% else %>
+                      <% 1.times do %>
                         <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %>">
                           <%= crop.emoji %>
                         </h2>

--- a/app/views/gardens/_garden.html.erb
+++ b/app/views/gardens/_garden.html.erb
@@ -56,11 +56,9 @@
 
                     <%# ------------- If more than 6 crops in bed ------------- %>
                     <% else %>
-                      <% 1.times do %>
-                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %> x <%= crop.quantity %>">
-                          <%= crop.emoji %>
-                        </h2>
-                      <% end %>
+                      <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %> x <%= crop.quantity %>">
+                        <%= crop.emoji %>
+                      </h2>
                     <% end %>
                   <% end %>
                 </div>

--- a/app/views/gardens/_garden.html.erb
+++ b/app/views/gardens/_garden.html.erb
@@ -37,10 +37,12 @@
                 <div class="d-flex flex-wrap justify-content-around">
                   <%# ------------- Plot crop emojis in bed ------------- %>
                   <% bed.crops.each do |crop| %>
-                    <% 3.times do %>
-                      <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %>">
-                        <%= crop.emoji %>
-                      </h2>
+                    <% if crop.planted? %>
+                      <% 3.times do %>
+                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %>">
+                          <%= crop.emoji %>
+                        </h2>
+                      <% end %>
                     <% end %>
                   <% end %>
                 </div>

--- a/app/views/gardens/_garden.html.erb
+++ b/app/views/gardens/_garden.html.erb
@@ -41,7 +41,7 @@
                     <%# ------------- If less that 4 crops in bed ------------- %>
                     <% if bed.planted_crops.length <= 4 %>
                       <% 3.times do %>
-                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %>">
+                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %> x <%= crop.quantity %>">
                           <%= crop.emoji %>
                         </h2>
                       <% end %>
@@ -49,7 +49,7 @@
                     <%# ------------- If 5-6 crops in bed ------------- %>
                     <% elsif bed.planted_crops.length <= 6 %>
                       <% 2.times do %>
-                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %>">
+                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %> x <%= crop.quantity %>">
                           <%= crop.emoji %>
                         </h2>
                       <% end %>
@@ -57,7 +57,7 @@
                     <%# ------------- If more than 6 crops in bed ------------- %>
                     <% else %>
                       <% 1.times do %>
-                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %>">
+                        <h2 class="m-2" data-toggle="tooltip" data-placement="top" title="<%= crop.veggie.name %> x <%= crop.quantity %>">
                           <%= crop.emoji %>
                         </h2>
                       <% end %>


### PR DESCRIPTION
- only crops that are `planted: true` display on Garden Index
- no. of emojis plotted per crop will change depending on no. of crops in bed
![image](https://user-images.githubusercontent.com/68765634/212458392-c85dc72b-f2e1-4960-9c77-ea1f8c31d0f0.png)

- only first 12 crops will have an emoji plotted
- tool tip updated to include crop quantity
![image](https://user-images.githubusercontent.com/68765634/212458357-69678ff5-04e2-49fa-8919-c3452ceaba2a.png)
