### PR TITLE
Planted boolean bug fix

### DIFF
--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -12,7 +12,7 @@ class Crop < ApplicationRecord
     message: "%<value> is not a valid season"
   }
   validates :plant_date, comparison: { less_than_or_equal_to: Date.today }, allow_nil: true
-  validates :planted, inclusion: [true, false]
+  validates :planted, presence: true, inclusion: [true, false]
 
   def harvested?
     plant_date && !planted

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -12,7 +12,7 @@ class Crop < ApplicationRecord
     message: "%<value> is not a valid season"
   }
   validates :plant_date, comparison: { less_than_or_equal_to: Date.today }, allow_nil: true
-  validates :planted, presence: true, inclusion: [true, false]
+  validates :planted, inclusion: [true, false]
 
   def harvested?
     plant_date && !planted

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -11,7 +11,7 @@ class Crop < ApplicationRecord
     in: %w[Summer Autumn Winter Spring],
     message: "%<value> is not a valid season"
   }
-  validates :plant_date, comparison: { less_than_or_equal_to: Date.today }, allow_nil: true
+  validates :plant_date, comparison: { less_than_or_equal_to: Date.today }, presence: true, allow_nil: false, if: :planted?
   validates :planted, inclusion: [true, false]
 
   def harvested?

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -12,6 +12,7 @@ class Crop < ApplicationRecord
     message: "%<value> is not a valid season"
   }
   validates :plant_date, comparison: { less_than_or_equal_to: Date.today }, allow_nil: true
+  validates :planted, inclusion: [true, false]
 
   def harvested?
     plant_date && !planted

--- a/app/views/gardens/_bed.html.erb
+++ b/app/views/gardens/_bed.html.erb
@@ -74,7 +74,8 @@
                       <%= f.input :planted,
                                   label: "Has the crop been planted?",
                                   as: :radio_buttons,
-                                  collection: [['Yes', true], ['No', false]] %>
+                                  collection: [['Yes', true], ['No', false]],
+                                  checked: ['No', false] %>
                     </div>
                     <div class="d-none" data-crop-form-target="date">
                       <%= f.input :plant_date,


### PR DESCRIPTION
Issue: could save a crop w `planted: nil` and there is no where to access these crops in the UI to remove/amend them

-  Crop model now validates on:
`validates :planted, presence: true, inclusion: [true, false]`

-  + Crop form has Planted ['No', false] checked by default
![image](https://user-images.githubusercontent.com/68765634/213316731-4820fc7c-cf27-47f7-b9f5-9e3a6948e449.png)
