### PR TITLE
Button audit

### DIFF
--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -14,7 +14,7 @@ $body-color: $gray;
 $primary: $yellowgreen;
 $success: $mossgreen;
 $info: $yellowcream;
-$danger: $red;
+$danger: $darkmoss;
 $warning: $background;
 
 // Buttons & inputs' radius

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -15,7 +15,7 @@ $primary: $yellowgreen;
 $success: $mossgreen;
 $info: $yellowcream;
 $danger: $red;
-$warning: $orange;
+$warning: $background;
 
 // Buttons & inputs' radius
 $border-radius: 2px;

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -13,7 +13,7 @@ $font-size-base: 1rem;
 $body-color: $gray;
 $primary: $yellowgreen;
 $success: $mossgreen;
-$info: $yellow;
+$info: $yellowcream;
 $danger: $red;
 $warning: $orange;
 

--- a/app/views/beds/_new.html.erb
+++ b/app/views/beds/_new.html.erb
@@ -7,7 +7,7 @@
   <div class="form-input">
     <div class="form-actions">
       <div class="col-lg-12 mb-0">
-        <div class="d-grid"> <%= f.button :submit, "Save Bed", class: "btn btn-primary" %></div>
+        <div class="d-grid"> <%= f.button :submit, "Save Bed", class: "btn btn-success text-light" %></div>
       </div>
     </div>
   </div>

--- a/app/views/gardens/_bed.html.erb
+++ b/app/views/gardens/_bed.html.erb
@@ -36,7 +36,7 @@
 
     <%# ------------- Add Crop Button ------------------ %>
     <div class="d-flex justify-content-end">
-      <a class="btn btn-primary m-2" data-bs-toggle="modal" href="#addcropmodal<%= bed.id %>" role="button">Add Crop</a>
+      <a class="btn btn-info m-2" data-bs-toggle="modal" href="#addcropmodal<%= bed.id %>" role="button">Add Crop</a>
     </div>
     <%# ------------- Planted Crop Cards ------------- %>
     <div class="d-flex justify-content-start flex-wrap flex-row">

--- a/app/views/gardens/_bed.html.erb
+++ b/app/views/gardens/_bed.html.erb
@@ -25,7 +25,7 @@
 
     <%# ------------- Add Crop Button ------------------ %>
     <div class="d-flex justify-content-end">
-      <a class="btn btn-primary m-2" data-bs-toggle="modal" href="#addcropmodal<%= bed.id %>" role="button"><i class="fa-solid fa-plus"></i> Crop</a>
+      <a class="btn btn-primary m-2" data-bs-toggle="modal" href="#addcropmodal<%= bed.id %>" role="button">Add Crop</a>
     </div>
     <%# ------------- Planted Crop Cards ------------- %>
     <div class="d-flex justify-content-start flex-wrap flex-row">
@@ -46,7 +46,7 @@
       <div class="modal-dialog modal-xl modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-header">
-            <h1 class="modal-title fs-5" id="addcropmodal<%= bed.id %>"><%= bed.description %> - Add a Crop</h1>
+            <h1 class="modal-title fs-5" id="addcropmodal<%= bed.id %>"><%= bed.description %> - Add Crop</h1>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
@@ -95,7 +95,7 @@
                                         selected: bed.id %>
                     </div>
                     <div class="btn btn-primary">
-                      <%= f.button :submit, "Add Crop" %>
+                      <%= f.button :submit, "Save Crop" %>
                     </div>
                   <% end %>
                 </div>
@@ -131,7 +131,7 @@
           </div>
           <div class="modal-footer">
             <p>Don't see the Veggie you want?</p>
-            <button class="btn btn-primary" data-bs-target="#addveggiemodal" data-bs-toggle="modal">Add new Veggie</button>
+            <button class="btn btn-primary" data-bs-target="#addveggiemodal" data-bs-toggle="modal">Add Veggie</button>
           </div>
         </div>
       </div>
@@ -142,7 +142,7 @@
       <div class="modal-dialog modal-xl modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-header">
-            <h1 class="modal-title fs-5" id="addveggiemodal">Create new Veggie</h1>
+            <h1 class="modal-title fs-5" id="addveggiemodal">Add Veggie</h1>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">

--- a/app/views/gardens/_bed.html.erb
+++ b/app/views/gardens/_bed.html.erb
@@ -6,20 +6,31 @@
       <div>
         <h2><%= bed.description %></h2>
       </div>
-      <div>
-        <%# ------------- Edit Bed Button ------------- %>
-        <%= link_to ('<i class="fa-solid fa-pencil"></i>').html_safe, edit_bed_path(bed), class:"btn btn-light" %>
 
-        <%# ------------- Delete Bed Button ------------- %>
-        <%= link_to ('<i class="fa-solid fa-trash-can"></i>').html_safe,
+      <%# Menu button %>
+      <div class="btn-group dropdown">
+        <button type="button" class="btn btn-light" data-bs-toggle="dropdown" aria-expanded="false">
+          <i class="fa-solid fa-bars text-success" style="font-size: 22px;"></i>
+        </button>
+        <ul class="dropdown-menu" style="min-width: 130px;">
+
+          <%# ------------- Edit Bed Button ------------- %>
+          <li>
+            <%= link_to ('<i class="fa-solid fa-pencil"></i> Edit Bed').html_safe, edit_bed_path(bed), class:"btn btn-light" %>
+          </li>
+
+          <%# ------------- Delete Bed Button ------------- %>
+          <li>
+            <%= link_to ('<i class="fa-solid fa-trash-can"></i> Delete Bed').html_safe,
                 bed,
                 data: {turbo_method: :delete, turbo_confirm: "Are you sure?" },
                 class: "btn btn-light"
               %>
+          </li>
+        </ul>
       </div>
     </div>
   </div>
-
 
   <div class="card-body bed-card">
 

--- a/app/views/gardens/_bed.html.erb
+++ b/app/views/gardens/_bed.html.erb
@@ -105,8 +105,8 @@
                                         include_blank: false,
                                         selected: bed.id %>
                     </div>
-                    <div class="btn btn-primary">
-                      <%= f.button :submit, "Save Crop" %>
+                    <div class="btn btn-success">
+                      <%= f.button :submit, "Save Crop", class: "text-light" %>
                     </div>
                   <% end %>
                 </div>
@@ -165,7 +165,7 @@
           </div>
           <div class="modal-footer">
             <%# TODO: fix this back button, may be easier to close instead - worse UI though %>
-            <button class="btn btn-primary" data-bs-target="#addcropmodal<%= bed.id %>" data-bs-toggle="modal">Back</button>
+            <button class="btn btn-warning" data-bs-target="#addcropmodal<%= bed.id %>" data-bs-toggle="modal"><i class="fa-regular fa-hand-point-left"></i> Back</button>
           </div>
         </div>
       </div>

--- a/app/views/gardens/_bed.html.erb
+++ b/app/views/gardens/_bed.html.erb
@@ -165,7 +165,7 @@
           </div>
           <div class="modal-footer">
             <%# TODO: fix this back button, may be easier to close instead - worse UI though %>
-            <button class="btn btn-warning" data-bs-target="#addcropmodal<%= bed.id %>" data-bs-toggle="modal"><i class="fa-regular fa-hand-point-left"></i> Back</button>
+            <button class="btn btn-warning border" data-bs-target="#addcropmodal<%= bed.id %>" data-bs-toggle="modal"><i class="fa-regular fa-hand-point-left"></i> Back</button>
           </div>
         </div>
       </div>

--- a/app/views/gardens/_crop.html.erb
+++ b/app/views/gardens/_crop.html.erb
@@ -11,12 +11,12 @@
 
           <%# Button for editing crop %>
           <li>
-            <a class="dropdown-item btn btn-light" data-bs-toggle="modal" href="#editcropmodal<%= crop.id %>"><i class="fa-solid fa-pencil h-60"></i> Edit crop</a>
+            <a class="dropdown-item btn btn-light" data-bs-toggle="modal" href="#editcropmodal<%= crop.id %>"><i class="fa-solid fa-pencil h-60"></i> Edit Crop</a>
           </li>
 
           <%# Button for deleting crop %>
           <li>
-            <%= link_to ('<i class="fa-solid fa-trash-can"></i> Delete crop').html_safe,
+            <%= link_to ('<i class="fa-solid fa-trash-can"></i> Delete Crop').html_safe,
               crop,
               data: {turbo_method: :delete, turbo_confirm: "Are you sure?" },
               class: "dropdown-item btn btn-light"

--- a/app/views/gardens/_garden.html.erb
+++ b/app/views/gardens/_garden.html.erb
@@ -76,7 +76,7 @@
               <div class="card-body">
                 <p class="card-text text-center m-4"></p>
                 <div class="m-10">
-                  <%= link_to "+ Bed", garden_path(garden),
+                  <%= link_to "Add Bed", garden_path(garden),
                     class: "btn btn-secondary btn-sm" %>
                 </div>
               </div>

--- a/app/views/gardens/_garden.html.erb
+++ b/app/views/gardens/_garden.html.erb
@@ -5,22 +5,36 @@
         <%# ------------- Link to Garden Show ------------- %>
         <h2><%= link_to garden.name, garden_path(garden) %></h2>
       </div>
-      <div>
-        <%# ------------- Icon link to Garden Show ------------- %>
-        <%= link_to ('<i class="fa-solid fa-eye"></i>').html_safe,
+
+      <%# Menu button %>
+      <div class="btn-group dropdown">
+        <button type="button" class="btn btn-light" data-bs-toggle="dropdown" aria-expanded="false">
+          <i class="fa-solid fa-bars text-success" style="font-size: 22px;"></i>
+        </button>
+        <ul class="dropdown-menu" style="min-width: 153px;">
+
+          <%# ------------- Icon link to Garden Show ------------- %>
+          <li>
+            <%= link_to ('<i class="fa-solid fa-binoculars"></i>').html_safe + " View Garden",
                 garden_path(garden),
                 class: "btn btn-light"
                 %>
+          </li>
 
-        <%# ------------- Edit Button ------------- %>
-        <%= render "partials/modal_edit_garden", garden: garden %>
+          <%# ------------- Edit Button (Currently doesn't do anything) ------------- %>
+          <li>
+            <%= render "partials/modal_edit_garden", garden: garden %>
+          </li>
 
-        <%# ------------- Delete Button ------------- %>
-        <%= link_to ('<i class="fa-solid fa-trash-can"></i>').html_safe,
+          <%# ------------- Delete Garden Button ------------- %>
+          <li>
+            <%= link_to ('<i class="fa-solid fa-trash-can"></i>').html_safe + " Delete Garden",
                 garden,
                 data: {turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this garden?" },
                 class: "btn btn-light"
                 %>
+          </li>
+        </ul>
       </div>
     </div>
   </div>

--- a/app/views/gardens/_new_garden_form.html.erb
+++ b/app/views/gardens/_new_garden_form.html.erb
@@ -7,7 +7,7 @@
     <div class="form-input">
       <div class="form-actions">
         <div class="col-lg-12 mb-0">
-          <div class="d-grid"> <%= f.button :submit, "Save Garden", class: "btn btn-primary" %></div>
+          <div class="d-grid"> <%= f.button :submit, "Save Garden", class: "btn btn-success text-light" %></div>
         </div>
       </div>
     </div>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -4,7 +4,7 @@
     <div class="modal-dialog modal-xl modal-dialog-centered">
       <div class="modal-content">
         <div class="modal-header">
-          <h1 class="modal-title fs-5" id="newbedmodal1">+ Garden</h1>
+          <h1 class="modal-title fs-5" id="newbedmodal1">Add Garden</h1>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -21,7 +21,7 @@
 
   <!-- ------------------------------- New Garden Button -------------------------------- -->
   <div class="d-flex justify-content-end">
-    <a class="btn btn-primary" data-bs-toggle="modal" href="#newbedmodal1" role="button">+ Garden</a>
+    <a class="btn btn-primary" data-bs-toggle="modal" href="#newbedmodal1" role="button">Add Garden</a>
   </div>
 
   <!-- ------------------------------- Display Garden Cards -------------------------------- -->

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -5,7 +5,7 @@
     <div class="modal-dialog modal-xl modal-dialog-centered">
       <div class="modal-content">
         <div class="modal-header">
-          <h1 class="modal-title fs-5" id="newbedmodal1">+ New Bed</h1>
+          <h1 class="modal-title fs-5" id="newbedmodal1">Add Bed</h1>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
@@ -26,7 +26,7 @@
             class: "btn btn-light"
           %>
   <!-- ------------------------------- New Bed button -------------------------------- -->
-    <a class="btn btn-primary" data-bs-toggle="modal" href="#newbedmodal1" role="button"><i class="fa-solid fa-plus"></i> Bed</a>
+    <a class="btn btn-primary" data-bs-toggle="modal" href="#newbedmodal1" role="button">Add Bed</a>
   </div>
   <!-- ------------------------------- list all beds in garden -------------------------------- -->
   <% if @beds %>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -23,7 +23,7 @@
     <!-- ------------------------------- Back to Gardens button -------------------------------- -->
     <%= link_to ('<i class="fa-regular fa-hand-point-left"></i> Back').html_safe,
             gardens_path,
-            class: "btn btn-light"
+            class: "btn btn-light border"
           %>
   <!-- ------------------------------- New Bed button -------------------------------- -->
     <a class="btn btn-primary" data-bs-toggle="modal" href="#newbedmodal1" role="button">Add Bed</a>

--- a/app/views/pages/history.html.erb
+++ b/app/views/pages/history.html.erb
@@ -19,7 +19,7 @@
           class: "form-control",
           placeholder: "Select a year"
         %>
-        <%= f.submit "Search", class: "btn btn-danger text-light" %>
+        <%= f.submit "View History", class: "btn btn-danger text-light" %>
       <% end %>
     </div>
 

--- a/app/views/pages/history.html.erb
+++ b/app/views/pages/history.html.erb
@@ -19,7 +19,7 @@
           class: "form-control",
           placeholder: "Select a year"
         %>
-        <%= f.submit "Search", class: "btn btn-primary" %>
+        <%= f.submit "Search", class: "btn btn-danger text-light" %>
       <% end %>
     </div>
 

--- a/app/views/pages/plans.html.erb
+++ b/app/views/pages/plans.html.erb
@@ -7,9 +7,9 @@
       <div class="input-group mb-3" style="width: 240px; margin-right: 12px;">
         <div class="d-flex">
           <div class="input-group-prepend">
-            <label class="input-group-text bg-primary border border-light" for="season">Season</label>
+            <label class="input-group-text bg-danger border text-light" for="season">Season</label>
           </div>
-          <select class="custom-select border border-light" id="season" data-action="change->filter-planned-crops#filterBySeason" data-filter-planned-crops-target="season">
+          <select class="custom-select border" id="season" data-action="change->filter-planned-crops#filterBySeason" data-filter-planned-crops-target="season">
             <option selected>Please select a season</option>
             <option value="Summer">Summer</option>
             <option value="Autumn">Autumn</option>

--- a/app/views/partials/_modal_edit_garden
+++ b/app/views/partials/_modal_edit_garden
@@ -45,4 +45,4 @@
 </div>
 
 <!-- ------------------------------- button -------------------------------- -->
-<a class="btn btn-light" data-bs-toggle="modal" href="#editgardenmodal1" role="button" data-toggle="tooltip" data-placement="top" title="Edit Garden"><i class="fa-solid fa-pencil"></i></a>
+<a class="btn btn-light" data-bs-toggle="modal" href="#editgardenmodal1" role="button" data-toggle="tooltip" data-placement="top" title="Edit Garden"><i class="fa-solid fa-pencil"></i> Edit Garden</a>

--- a/app/views/veggies/_veggie_form.html.erb
+++ b/app/views/veggies/_veggie_form.html.erb
@@ -6,6 +6,6 @@
   </div>
   <br>
   <div class="btn btn-primary">
-    <%= f.button :submit, "Create Veggie" %>
+    <%= f.button :submit, "Save Veggie" %>
   </div>
 <% end %>

--- a/app/views/veggies/_veggie_form.html.erb
+++ b/app/views/veggies/_veggie_form.html.erb
@@ -5,7 +5,7 @@
     <%= f.select :season, %w[Summer Autumn Winter Spring] %>
   </div>
   <br>
-  <div class="btn btn-primary">
-    <%= f.button :submit, "Save Veggie" %>
+  <div class="btn btn-success">
+    <%= f.button :submit, "Save Veggie", class: "text-light" %>
   </div>
 <% end %>


### PR DESCRIPTION
- All new buttons now read "add" instead of using "+"
- Bed and Garden edit/show/delete actions are all stored within a menu button (aligned w crop card)
- Updated colour of "Add crop" button so it's not the same as "Add bed" (on the same page)
- Updated all "save" buttons to be moss green w white text
- back buttons are either white if against background colour or background colour if on white background

<img width="731" alt="image" src="https://user-images.githubusercontent.com/68765634/213908278-7dfa4a0f-87ab-4818-9088-319af0b23122.png">

<img width="517" alt="image" src="https://user-images.githubusercontent.com/68765634/213908914-4fda9578-63b5-475d-9462-2b74532a521b.png">

