### PR TITLE
Updated image tag for notice worm

### DIFF
--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,6 +1,6 @@
 <% if notice %>
   <div class="alert alert-info alert-dismissible fade show m-1 talkbubble" role="alert">
-    <%= image_tag "notice_worm", class: "worm-helper" %>
+    <%= image_tag "notice_worm.png", class: "worm-helper" %>
     <div class="textarea">
       <p class="m-0" style="width:190px;">
         <%= notice %>


### PR DESCRIPTION
Updated image tag for worm_notice as it's causing errors on Heroku:

![image](https://user-images.githubusercontent.com/68765634/214267769-5e35587c-25fc-4f01-abf4-18d59f94654a.png)
