### PR TITLE
button is no beds card now reads "Get Started"

### DIFF
--- a/app/views/gardens/_garden.html.erb
+++ b/app/views/gardens/_garden.html.erb
@@ -83,18 +83,10 @@
       <% end %>
       <%# ------------- No Beds Display ------------- %>
       <% if garden.beds.empty? %>
-        <div class="card no-plot-bed">
-
-          <div class="d-flex flex-column">
-            <div class="align-self-center">
-              <div class="card-body">
-                <p class="card-text text-center m-4"></p>
-                <div class="m-10">
-                  <%= link_to "Add Bed", garden_path(garden),
-                    class: "btn btn-secondary btn-sm btn-pulse-secondary" %>
-                </div>
-              </div>
-            </div>
+        <div class="card no-plot-bed" style="padding: 120px 30px;">
+          <div class="align-self-center">
+            <%= link_to "Get Started", garden_path(garden),
+                class: "btn btn-secondary btn-sm btn-pulse-secondary" %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
- was previously "add bed" -> deem confusing as you would need to click "add bed" on garden show
-button is now centred in the card

![image](https://user-images.githubusercontent.com/68765634/214287634-8a34f1d2-c5ab-4d6d-b811-aa14158d3e7c.png)