### PR TITLE
Eye Icon > garden show page now a "View Garden" button

### DIFF
--- a/app/views/pages/_historic_garden.html.erb
+++ b/app/views/pages/_historic_garden.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div>
         <%# ------------- Icon link to Garden Show ------------- %>
-        <%= link_to ('<i class="fa-solid fa-eye"></i>').html_safe,
+        <%= link_to ('<i class="fa-solid fa-binoculars"></i> View Garden').html_safe,
                 garden_path(garden),
                 class: "btn btn-light"
                 %>

--- a/app/views/pages/_planned_garden.html.erb
+++ b/app/views/pages/_planned_garden.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div>
         <%# ------------- Icon link to Garden Show ------------- %>
-        <%= link_to ('<i class="fa-solid fa-eye"></i>').html_safe,
+        <%= link_to ('<i class="fa-solid fa-binoculars"></i> View Garden').html_safe,
                 garden_path(garden),
                 class: "btn btn-light"
                 %>


### PR DESCRIPTION
- Based off feedback from Julian, eye icon is now a "View Garden" button on Plans and History pages

Before:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/68765634/214977838-2af1a607-6b93-4f06-a627-819b90f8d6ab.png">


After:
<img width="288" alt="image" src="https://user-images.githubusercontent.com/68765634/214977764-be8ccbc7-0a3e-4a8f-90f7-3e5ff5972735.png">
