### PR TITLE
Add card containers to allow for more breathing room on the page

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -58,9 +58,9 @@
  }
 
  .main-card-container {
-  padding: 0px 60px;
+  padding: 0px 150px;
  }
 
- .crops-card-container {
-  padding: 0px 60px;
+ .secondary-card-container {
+  padding: 0px 50px;
  }

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -58,6 +58,9 @@
  }
 
  .main-card-container {
-  padding: 0px 50px;
-  background-color: none;
+  padding: 0px 60px;
+ }
+
+ .crops-card-container {
+  padding: 0px 60px;
  }

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -56,3 +56,7 @@
     color: $mossgreen;
   }
  }
+
+ .main-card-container {
+  padding: 0px 50px;
+ }

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -59,4 +59,5 @@
 
  .main-card-container {
   padding: 0px 50px;
+  background-color: none;
  }

--- a/app/assets/stylesheets/components/_garden.scss
+++ b/app/assets/stylesheets/components/_garden.scss
@@ -1,5 +1,6 @@
 .garden{
   background-image: url(garden_background_colour_low_o.png);
+  overflow: hidden;
   background-repeat: repeat;
   background-size: cover;
   min-height: 400px;

--- a/app/views/gardens/_bed.html.erb
+++ b/app/views/gardens/_bed.html.erb
@@ -1,6 +1,6 @@
 <% require_relative '../../../db/crop_emojis' %>
 
-<div class="card my-3">
+<div class="card my-4">
   <div class="card-header">
     <div class="d-flex justify-content-between">
       <div>
@@ -38,7 +38,7 @@
     <div class="d-flex justify-content-end">
       <a class="btn btn-info shadow-sm m-2 <%= "btn-pulse-primary" if bed.planted_crops.empty? && bed.future_crops.empty? %>" data-bs-toggle="modal" href="#addcropmodal<%= bed.id %>" role="button">Add Crop</a>
     </div>
-    <div class="main-card-container">
+    <%# <div class="secondary-card-container"> %>
     <%# ------------- Planted Crop Cards ------------- %>
     <div class="d-flex justify-content-start flex-wrap flex-row">
         <% bed.planted_crops.order(:season).each do |crop| %>
@@ -52,7 +52,7 @@
           <%= render "crop", crop: crop, bed: bed %>
         <% end %>
     </div>
-    </div>
+    <%# </div> %>
     <%# ------------- Modal for adding a crop ------------------ %>
     <div class="modal fade" id="addcropmodal<%= bed.id %>" aria-hidden="true" aria-labelledby="addcropmodal<%= bed.id %>" tabindex="-1">
       <div class="modal-dialog modal-lg modal-dialog-centered">

--- a/app/views/gardens/_bed.html.erb
+++ b/app/views/gardens/_bed.html.erb
@@ -41,14 +41,14 @@
     <div class="main-card-container">
     <%# ------------- Planted Crop Cards ------------- %>
     <div class="d-flex justify-content-start flex-wrap flex-row">
-        <% bed.planted_crops.each do |crop| %>
+        <% bed.planted_crops.order(:season).each do |crop| %>
           <%= render "crop", crop: crop %>
         <% end %>
     </div>
 
     <%# ------------- Unplanted Crop Cards ------------- %>
     <div class="d-flex justify-content-start flex-wrap flex-row">
-        <% bed.future_crops.each do |crop| %>
+        <% bed.future_crops.order(:season).each do |crop| %>
           <%= render "crop", crop: crop, bed: bed %>
         <% end %>
     </div>

--- a/app/views/gardens/_bed.html.erb
+++ b/app/views/gardens/_bed.html.erb
@@ -38,6 +38,7 @@
     <div class="d-flex justify-content-end">
       <a class="btn btn-info shadow-sm m-2 <%= "btn-pulse-primary" if bed.planted_crops.empty? && bed.future_crops.empty? %>" data-bs-toggle="modal" href="#addcropmodal<%= bed.id %>" role="button">Add Crop</a>
     </div>
+    <div class="main-card-container">
     <%# ------------- Planted Crop Cards ------------- %>
     <div class="d-flex justify-content-start flex-wrap flex-row">
         <% bed.planted_crops.each do |crop| %>
@@ -51,7 +52,7 @@
           <%= render "crop", crop: crop, bed: bed %>
         <% end %>
     </div>
-
+    </div>
     <%# ------------- Modal for adding a crop ------------------ %>
     <div class="modal fade" id="addcropmodal<%= bed.id %>" aria-hidden="true" aria-labelledby="addcropmodal<%= bed.id %>" tabindex="-1">
       <div class="modal-dialog modal-lg modal-dialog-centered">

--- a/app/views/gardens/_crop.html.erb
+++ b/app/views/gardens/_crop.html.erb
@@ -1,4 +1,4 @@
-<div class="card border-0 m-2 crop-card">
+<div class="card border-0 m-3 crop-card">
   <div class="card-header crop-card-header">
     <div class="d-flex justify-content-between">
       <%# Name and emoji %>

--- a/app/views/gardens/_crop.html.erb
+++ b/app/views/gardens/_crop.html.erb
@@ -1,4 +1,4 @@
-<div class="card border-0 m-3 crop-card">
+<div class="card border-0 mx-2 my-4 crop-card">
   <div class="card-header crop-card-header">
     <div class="d-flex justify-content-between">
       <%# Name and emoji %>

--- a/app/views/gardens/_garden.html.erb
+++ b/app/views/gardens/_garden.html.erb
@@ -1,4 +1,4 @@
-<div class="card my-3">
+<div class="card my-4">
   <div class="card-header garden-header">
     <div class="d-flex justify-content-between">
       <div>
@@ -39,49 +39,51 @@
     </div>
   </div>
   <div class="card-body garden current">
-    <% if garden.beds %>
-      <div class="d-flex flex-wrap justify-content-start">
-        <%# ------------- Iterate over beds in garden ------------- %>
-        <% garden.beds.each do |bed|%>
-          <div class="mt-2 mx-4">
-            <%# ------------- Bed description badge ------------- %>
-            <span class="badge rounded-4 badge-primary ms-1 mb-2"><%= bed.description %></span>
-            <div class="card plot-bed">
-              <div class="card-body current-crop-body">
-                <div class="d-flex flex-wrap justify-content-around">
-                  <%# ------------- Plot crop emojis in bed (max 12) ------------- %>
-                  <% bed.planted_crops.first(12).each do |crop| %>
+    <div class="secondary-card-container">
+      <% if garden.beds %>
+        <div class="d-flex flex-wrap justify-content-start">
+          <%# ------------- Iterate over beds in garden ------------- %>
+          <% garden.beds.each do |bed|%>
+            <div class="mt-2 mx-4">
+              <%# ------------- Bed description badge ------------- %>
+              <span class="badge rounded-4 badge-primary ms-1 mb-2"><%= bed.description %></span>
+              <div class="card plot-bed mb-2">
+                <div class="card-body current-crop-body">
+                  <div class="d-flex flex-wrap justify-content-around">
+                    <%# ------------- Plot crop emojis in bed (max 12) ------------- %>
+                    <% bed.planted_crops.first(12).each do |crop| %>
 
-                    <%# ------------- If 1-2 crops in bed ------------- %>
-                    <% if bed.planted_crops.length <= 2 %>
-                      <% 6.times do %>
+                      <%# ------------- If 1-2 crops in bed ------------- %>
+                      <% if bed.planted_crops.length <= 2 %>
+                        <% 6.times do %>
+                          <%= render "crops/crop_modal", crop: crop, bed: bed, season: crop.season %>
+                        <% end %>
+
+                      <%# ------------- If less that 4 crops in bed ------------- %>
+                      <% elsif bed.planted_crops.length <= 4 %>
+                        <% 3.times do %>
+                          <%= render "crops/crop_modal", crop: crop, bed: bed, season: crop.season %>
+                        <% end %>
+
+                      <%# ------------- If 5-6 crops in bed ------------- %>
+                      <% elsif bed.planted_crops.length <= 6 %>
+                        <% 2.times do %>
+                          <%= render "crops/crop_modal", crop: crop, bed: bed, season: crop.season %>
+                        <% end %>
+
+                      <%# ------------- If more than 6 crops in bed ------------- %>
+                      <% else %>
                         <%= render "crops/crop_modal", crop: crop, bed: bed, season: crop.season %>
                       <% end %>
-
-                    <%# ------------- If less that 4 crops in bed ------------- %>
-                    <% elsif bed.planted_crops.length <= 4 %>
-                      <% 3.times do %>
-                        <%= render "crops/crop_modal", crop: crop, bed: bed, season: crop.season %>
-                      <% end %>
-
-                    <%# ------------- If 5-6 crops in bed ------------- %>
-                    <% elsif bed.planted_crops.length <= 6 %>
-                      <% 2.times do %>
-                        <%= render "crops/crop_modal", crop: crop, bed: bed, season: crop.season %>
-                      <% end %>
-
-                    <%# ------------- If more than 6 crops in bed ------------- %>
-                    <% else %>
-                      <%= render "crops/crop_modal", crop: crop, bed: bed, season: crop.season %>
                     <% end %>
-                  <% end %>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
   <%# ------------- No Beds Display ------------- %>
     <% if garden.beds.empty? %>
       <div class="d-flex justify-content-center">

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -29,20 +29,20 @@
     <!-- ------------------------------- New Garden Button -------------------------------- -->
     <a class="btn btn-primary shadow-sm <%= "btn-pulse-primary" if @gardens.empty? %> align-self-start" style="width:160px;" data-bs-toggle="modal" href="#newbedmodal1" role="button">Add Garden</a>
   </div>
-  <div class="container main-card-container">
-  <% if @gardens %>
-  <!-- ------------------------------- Display Garden Cards -------------------------------- -->
-    <% @gardens.each do |garden| %>
-      <%= render "garden", garden: garden %>
+  <div class="main-card-container">
+    <% if @gardens %>
+    <!-- ------------------------------- Display Garden Cards -------------------------------- -->
+      <% @gardens.each do |garden| %>
+        <%= render "garden", garden: garden %>
+      <% end %>
+    <% else %>
+      <div class="card my-3">
+        <div class="card-header">
+          <h2>You don't have any gardens yet</h2>
+        </div>
+        <div class="card-body no-gardens">
+        </div>
+      </div>
     <% end %>
-  <% else %>
-    <div class="card my-3">
-      <div class="card-header">
-        <h2>You don't have any gardens yet</h2>
-      </div>
-      <div class="card-body no-gardens">
-      </div>
-    </div>
-  <% end %>
-</div>
+  </div>
 </div>

--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -29,6 +29,7 @@
     <!-- ------------------------------- New Garden Button -------------------------------- -->
     <a class="btn btn-primary shadow-sm <%= "btn-pulse-primary" if @gardens.empty? %> align-self-start" style="width:160px;" data-bs-toggle="modal" href="#newbedmodal1" role="button">Add Garden</a>
   </div>
+  <div class="container main-card-container">
   <% if @gardens %>
   <!-- ------------------------------- Display Garden Cards -------------------------------- -->
     <% @gardens.each do |garden| %>
@@ -43,4 +44,5 @@
       </div>
     </div>
   <% end %>
+</div>
 </div>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -33,20 +33,22 @@
     <a class="btn btn-primary shadow-sm <%= "btn-pulse-primary" if @beds.empty? %> align-self-start" style="width:120px;" data-bs-toggle="modal" href="#newbedmodal1" role="button">Add Bed</a>
   </div>
   <!-- ------------------------------- list all beds in garden -------------------------------- -->
-  <% if @beds %>
-    <% @beds.reverse.each do |bed| %>
-      <%= render "bed", bed: bed %>
+  <div class="main-card-container">
+    <% if @beds %>
+      <% @beds.reverse.each do |bed| %>
+        <%= render "bed", bed: bed %>
+      <% end %>
     <% end %>
-  <% end %>
 
-  <!-- ------------------------------- list all beds in garden -------------------------------- -->
-  <% if @beds.empty? %>
-    <div class="card my-3">
-      <div class="card-header">
-        <h2>You don't have any beds yet</h2>
+    <!-- ------------------------------- list all beds in garden -------------------------------- -->
+    <% if @beds.empty? %>
+      <div class="card my-3">
+        <div class="card-header">
+          <h2>You don't have any beds yet</h2>
+        </div>
+        <div class="card-body no-beds">
+        </div>
       </div>
-      <div class="card-body no-beds">
-      </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/pages/_historic_garden.html.erb
+++ b/app/views/pages/_historic_garden.html.erb
@@ -1,5 +1,5 @@
 <!-- ------------------------------- Garden -------------------------------- -->
-<div class="card my-3">
+<div class="card my-4">
   <div class="card-header garden-header">
     <div class="d-flex justify-content-between">
       <div>
@@ -15,26 +15,28 @@
     </div>
   </div>
   <div class="card-body historic-garden">
-    <% if garden.beds %>
-      <div class="d-flex flex-wrap justify-content-start">
-        <%# ------------- Iterate over beds in garden ------------- %>
-        <% garden.beds.each do |bed|%>
-          <div class="mt-2 mx-4">
-            <%# ------------- Bed description badge ------------- %>
-            <span class="badge badge-primary rounded-4 ms-1 mb-2"><%= bed.description %></span>
-            <div class="card plot-bed">
-              <div class="card-body">
+    <div class="secondary-card-container">
+      <% if garden.beds %>
+        <div class="d-flex flex-wrap justify-content-start">
+          <%# ------------- Iterate over beds in garden ------------- %>
+          <% garden.beds.each do |bed|%>
+            <div class="mt-2 mx-4">
+              <%# ------------- Bed description badge ------------- %>
+              <span class="badge badge-primary rounded-4 ms-1 mb-2"><%= bed.description %></span>
+              <div class="card mb-2 plot-bed">
+                <div class="card-body">
 
-                <%# ------------- Crops by season ------------- %>
-                <div class="d-flex flex-wrap justify-content-around">
-                  <%= render "crop_by_season_and_year", bed: bed, season: season, year: year %>
+                  <%# ------------- Crops by season ------------- %>
+                  <div class="d-flex flex-wrap justify-content-around">
+                    <%= render "crop_by_season_and_year", bed: bed, season: season, year: year %>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
       <%# ------------- No Beds Display ------------- %>
     <% if garden.beds.empty? %>
       <div class="d-flex flex-wrap justify-content-center">

--- a/app/views/pages/_planned_garden.html.erb
+++ b/app/views/pages/_planned_garden.html.erb
@@ -1,5 +1,5 @@
 <!-- ------------------------------- Garden -------------------------------- -->
-<div class="card my-3">
+<div class="card my-4">
   <div class="card-header garden-header">
     <div class="d-flex justify-content-between">
       <div>
@@ -15,37 +15,39 @@
     </div>
   </div>
   <div class="card-body planned-garden">
-    <% if garden.beds %>
-      <div class="d-flex flex-wrap justify-content-start">
-        <%# ------------- Iterate over beds in garden ------------- %>
-        <% garden.beds.each do |bed|%>
-          <div class="mt-2 mx-4">
+    <div class="secondary-card-container">
+      <% if garden.beds %>
+        <div class="d-flex flex-wrap justify-content-start">
+          <%# ------------- Iterate over beds in garden ------------- %>
+          <% garden.beds.each do |bed|%>
+            <div class="mt-2 mx-4">
 
-            <%# ------------- Bed description badge ------------- %>
-            <span class="badge rounded-4 badge-primary ms-1 mb-2"><%= bed.description %></span>
-            <div class="card plot-bed">
-              <div class="card-body">
+              <%# ------------- Bed description badge ------------- %>
+              <span class="badge rounded-4 badge-primary ms-1 mb-2"><%= bed.description %></span>
+              <div class="card mb-2 plot-bed">
+                <div class="card-body">
 
-                <%# ------------- Crops by season ------------- %>
+                  <%# ------------- Crops by season ------------- %>
 
-                <div class="d-flex flex-wrap justify-content-around">
-                  <%= render "crop_by_season", bed: bed, season: "Summer" %>
-                </div>
-                <div class="d-flex flex-wrap justify-content-around">
-                  <%= render "crop_by_season", bed: bed, season: "Autumn" %>
-                </div>
-                <div class="d-flex flex-wrap justify-content-around">
-                  <%= render "crop_by_season", bed: bed, season: "Winter" %>
-                </div>
-                <div class="d-flex flex-wrap justify-content-around">
-                  <%= render "crop_by_season", bed: bed, season: "Spring" %>
+                  <div class="d-flex flex-wrap justify-content-around">
+                    <%= render "crop_by_season", bed: bed, season: "Summer" %>
+                  </div>
+                  <div class="d-flex flex-wrap justify-content-around">
+                    <%= render "crop_by_season", bed: bed, season: "Autumn" %>
+                  </div>
+                  <div class="d-flex flex-wrap justify-content-around">
+                    <%= render "crop_by_season", bed: bed, season: "Winter" %>
+                  </div>
+                  <div class="d-flex flex-wrap justify-content-around">
+                    <%= render "crop_by_season", bed: bed, season: "Spring" %>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
       <%# ------------- No Beds Display ------------- %>
     <% if garden.beds.empty? %>
       <div class="d-flex flex-wrap justify-content-center">

--- a/app/views/pages/history.html.erb
+++ b/app/views/pages/history.html.erb
@@ -30,19 +30,21 @@
     </div>
 
     <%# ------------- Garden Cards ------------- %>
-    <% if @gardens %>
-      <% @gardens.each do |garden| %>
-        <%= render "historic_garden", garden: garden, season: @season, year: @year %>
+    <div class="main-card-container">
+      <% if @gardens %>
+        <% @gardens.each do |garden| %>
+          <%= render "historic_garden", garden: garden, season: @season, year: @year %>
+        <% end %>
       <% end %>
-    <% end %>
-    <% if @gardens.empty? %>
-      <div class="card my-3">
-        <div class="card-header">
-          <h2>You don't have any gardens yet</h2>
+      <% if @gardens.empty? %>
+        <div class="card my-3">
+          <div class="card-header">
+            <h2>You don't have any gardens yet</h2>
+          </div>
+          <div class="card-body no-gardens">
+          </div>
         </div>
-        <div class="card-body no-gardens">
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/pages/plans.html.erb
+++ b/app/views/pages/plans.html.erb
@@ -24,19 +24,21 @@
         </div>
       </div>
     </div>
-    <% if @gardens %>
-      <% @gardens.each do |garden| %>
-        <%= render "planned_garden", garden: garden %>
+    <div class="main-card-container">
+      <% if @gardens %>
+        <% @gardens.each do |garden| %>
+          <%= render "planned_garden", garden: garden %>
+        <% end %>
       <% end %>
-    <% end %>
-    <% if @gardens.empty? %>
-      <div class="card my-3">
-        <div class="card-header">
-          <h2>You don't have any gardens yet</h2>
+      <% if @gardens.empty? %>
+        <div class="card my-3">
+          <div class="card-header">
+            <h2>You don't have any gardens yet</h2>
+          </div>
+          <div class="card-body no-gardens">
+          </div>
         </div>
-        <div class="card-body no-gardens">
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Added containers w additional padding around garden cards, bed cards and crop cards to better space them across the page. Each card should allow for 3 plotted beds/crops when fullscreen on mac:

<img width="1343" alt="image" src="https://user-images.githubusercontent.com/68765634/215017067-f97f0b3b-4129-4491-a5e8-2142ef132e93.png">

<img width="1400" alt="image" src="https://user-images.githubusercontent.com/68765634/215017161-513b36b6-45c6-4715-89e9-9acb7fb43195.png">

