### PR TITLE
Plans page bug

### DIFF
--- a/app/javascript/controllers/filter_planned_crops_controller.js
+++ b/app/javascript/controllers/filter_planned_crops_controller.js
@@ -4,6 +4,9 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["season", "crop"]
   connect() {
+    this.cropTargets.forEach((target) => {
+      target.classList.add("d-none")
+    });
   };
 
   filterBySeason(event) {

--- a/app/views/pages/_crop_by_season.html.erb
+++ b/app/views/pages/_crop_by_season.html.erb
@@ -1,14 +1,20 @@
+
 <%# ------------- Plot crop emojis in bed (max 12) ------------- %>
 <% bed.future_crops.where(season: season).first(12).each do |crop| %>
+<%# ------------- If less that 2 crops in bed ------------- %>
+  <% if bed.future_crops.where(season: season).length <= 2 %>
+    <% 6.times do %>
+      <%= render "crops/crop_modal", crop: crop, bed: bed, season: season %>
+    <% end %>
 
 <%# ------------- If less that 4 crops in bed ------------- %>
-  <% if bed.future_crops.length <= 4 %>
+  <% elsif bed.future_crops.where(season: season).length <= 4 %>
     <% 3.times do %>
       <%= render "crops/crop_modal", crop: crop, bed: bed, season: season %>
     <% end %>
 
   <%# ------------- If 5-6 crops in bed ------------- %>
-  <% elsif bed.future_crops.length <= 6 %>
+  <% elsif bed.future_crops.where(season: season).length <= 6 %>
     <% 2.times do %>
       <%= render "crops/crop_modal", crop: crop, bed: bed, season: season %>
     <% end %>

--- a/app/views/pages/_crop_by_season_and_year.html.erb
+++ b/app/views/pages/_crop_by_season_and_year.html.erb
@@ -2,7 +2,7 @@
 <% filtered_crops = bed.past_crops.where(season: season).where('extract(year from plant_date) = ?', year) %>
 <% return if filtered_crops.empty? %>
 <% filtered_crops.first(12).each do |crop| %>
-<%# ------------- If less that 4 crops in bed ------------- %>
+<%# ------------- If less that 2 crops in bed ------------- %>
   <% if filtered_crops.length <= 2 %>
     <% 6.times do %>
       <%= render "crops/crop_modal", crop: crop, bed: bed, season: season %>


### PR DESCRIPTION
All planned crops displaying by default when you first navigate to plans page - see pic

- updated connected so no crops will be shown when you first navigate to plans page
- updated logic to take into account season before calculating no of crops in the bed
- updated emoji plot login so 6 emojis are plotted for seasonal beds w 2 crops or less

Bug:

<img width="994" alt="image" src="https://user-images.githubusercontent.com/68765634/215020625-6398e997-627d-46a8-a430-858e29dfee99.png">
