### PR TITLE
Title and subnav update

### DIFF
--- a/app/views/gardens/index.html.erb
+++ b/app/views/gardens/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container p-10">
+<div class="container main-card-container">
   <!-- ------------------------------- modal1 -------------------------------- -->
   <div class="modal fade" id="newbedmodal1" aria-hidden="true" aria-labelledby="newbedmodal1" tabindex="-1">
     <div class="modal-dialog modal-xl modal-dialog-centered">
@@ -18,18 +18,18 @@
       </div>
     </div>
   </div>
+   <!-- ------------------------------- Title -------------------------------- -->
+    <% title = @gardens.length <=1 ? "Garden Overview" : "Gardens Overview" %>
+    <div class="align-self-start mb-3"><h1><%= title %></h1></div>
 
   <!-- ------------------------------- Sub nav -------------------------------- -->
   <div class="d-flex justify-content-between align-items-top">
-    <!-- ------------------------------- Title -------------------------------- -->
-    <% title = @gardens.length <=1 ? "Garden Overview" : "Gardens Overview" %>
-    <div class="align-self-start"><h1 style="color:#5a8231;"><%= title %></h1></div>
     <!-- ------------------------------- Info helper -------------------------------- -->
     <%= render "shared/page_info", empty: @gardens.empty? %>
     <!-- ------------------------------- New Garden Button -------------------------------- -->
     <a class="btn btn-primary <%= "btn-pulse-primary" if @gardens.empty? %> align-self-start" style="width:160px;" data-bs-toggle="modal" href="#newbedmodal1" role="button">Add Garden</a>
   </div>
-  <div class="main-card-container">
+  <%# <div class="main-card-container"> %>
     <% if @gardens %>
     <!-- ------------------------------- Display Garden Cards -------------------------------- -->
       <% @gardens.each do |garden| %>
@@ -44,5 +44,5 @@
         </div>
       </div>
     <% end %>
-  </div>
+  <%# </div> %>
 </div>

--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -1,4 +1,4 @@
-<div class="container p-10">
+<div class="container main-card-container">
 
   <!-- ------------------------------- NEW BED modal1 -------------------------------- -->
   <div class="modal fade" id="newbedmodal1" aria-hidden="true" aria-labelledby="newbedmodal1" tabindex="-1">
@@ -19,10 +19,13 @@
     </div>
   </div>
 
+  <!-- ------------------------------- Title -------------------------------- -->
+  <div class="align-self-start mb-3"><h1><%= @garden.name %></h1></div>
+
   <!-- --------------- sub nav ------------------- -->
   <div class="d-flex justify-content-between align-items-top">
     <!-- ------------------------------- Back to Gardens button -------------------------------- -->
-    <%= link_to ('<i class="fa-regular fa-hand-point-left"></i> Back').html_safe,
+    <%# <%= link_to ('<i class="fa-regular fa-hand-point-left"></i> Back').html_safe,
             gardens_path,
             class: "btn btn-light align-self-start shadow-sm",
             style: "width:120px;"
@@ -33,7 +36,7 @@
     <a class="btn btn-primary <%= "btn-pulse-primary" if @beds.empty? %> align-self-start" style="width:120px;" data-bs-toggle="modal" href="#newbedmodal1" role="button">Add Bed</a>
   </div>
   <!-- ------------------------------- list all beds in garden -------------------------------- -->
-  <div class="main-card-container">
+  <%# <div class="main-card-container"> %>
     <% if @beds %>
       <% @beds.reverse.each do |bed| %>
         <%= render "bed", bed: bed %>
@@ -50,5 +53,5 @@
         </div>
       </div>
     <% end %>
-  </div>
+  <%# </div> %>
 </div>

--- a/app/views/pages/history.html.erb
+++ b/app/views/pages/history.html.erb
@@ -1,11 +1,12 @@
-<div class="container p-10">
+<div class="container main-card-container">
   <div data-controller="filter-planned-crops">
+
+    <!-- --------------- title ------------------- -->
+    <div class="mb-3"><h1>History</h1></div>
+
     <!-- --------------- sub nav ------------------- -->
     <div class="d-flex justify-content-between align-items-top garden-header">
-      <!-- --------------- title ------------------- -->
-      <div class="align-self-start">
-        <h1>History</h1>
-      </div>
+
       <!-- --------------- Info Helper ------------------- -->
       <%= render "shared/page_info", empty: @gardens.empty? %>
       <%# ------------- Form to select year and season ------------- %>
@@ -30,7 +31,7 @@
     </div>
 
     <%# ------------- Garden Cards ------------- %>
-    <div class="main-card-container">
+    <%# <div class="main-card-container"> %>
       <% if @gardens %>
         <% @gardens.each do |garden| %>
           <%= render "historic_garden", garden: garden, season: @season, year: @year %>
@@ -45,6 +46,6 @@
           </div>
         </div>
       <% end %>
-    </div>
+    <%# </div> %>
   </div>
 </div>

--- a/app/views/pages/plans.html.erb
+++ b/app/views/pages/plans.html.erb
@@ -1,13 +1,15 @@
-<div class="container p-10">
+<div class="container main-card-container">
   <div data-controller="filter-planned-crops">
+
+    <!-- --------------- title ------------------- -->
+    <div class="mb-3"><h1>Plans</h1></div>
+
     <!-- --------------- sub nav ------------------- -->
     <div class="d-flex justify-content-between align-items-top garden-header">
-      <!-- --------------- title ------------------- -->
-      <div>
-        <h1>Plans</h1>
-      </div>
+
       <!-- --------------- Info Helper ------------------- -->
       <%= render "shared/page_info", empty: @gardens.empty? %>
+
       <!-- --------------- Filter form ------------------- -->
       <div class="input-group align-self-start mb-3" style="width: 240px; margin-right: 12px;">
         <div class="d-flex">
@@ -24,7 +26,7 @@
         </div>
       </div>
     </div>
-    <div class="main-card-container">
+    <%# <div class=""> %>
       <% if @gardens %>
         <% @gardens.each do |garden| %>
           <%= render "planned_garden", garden: garden %>
@@ -39,6 +41,6 @@
           </div>
         </div>
       <% end %>
-    </div>
+    <%# </div> %>
   </div>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar navbar-expand-sm navbar-light navbar-lewagon mb-5" style="paddig-bottom: none;">
+<div class="navbar navbar-expand-sm navbar-light navbar-lewagon mb-3" style="paddig-bottom: none;">
   <div class="container-fluid">
     <%= link_to root_path, class: "navbar-brand" do %>
       <%= image_tag "logo.png" %> Roots

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,4 +1,5 @@
-<div class="navbar navbar-expand-sm navbar-light navbar-lewagon mb-3" style="paddig-bottom: none;">
+<div class="navbar navbar-expand-sm navbar-light navbar-lewagon mb-1
+" style="paddig-bottom: none;">
   <div class="container-fluid">
     <%= link_to root_path, class: "navbar-brand" do %>
       <%= image_tag "logo.png" %> Roots

--- a/app/views/shared/_page_info.html.erb
+++ b/app/views/shared/_page_info.html.erb
@@ -1,4 +1,4 @@
-<div class="page-info w-100 px-4">
+<div class="page-info w-100 ms-0">
   <div class="card rounded-4">
     <a data-bs-toggle="collapse" href="#collapseBody" aria-expanded="<%= empty %>">
       <div class="card-header w-100">


### PR DESCRIPTION
- Page title and subnav now is the same container as cards
- Title moved above the subnav
- removed the 'Back' button on the garden show page - didn't make sense that this was the only page that had it

<img width="1110" alt="image" src="https://user-images.githubusercontent.com/68765634/215089829-0f5c2a79-2ef1-4fee-84c8-de8f335d07b0.png">
