### PR TITLE
Fixed plans page

### DIFF
--- a/app/javascript/controllers/filter_planned_crops_controller.js
+++ b/app/javascript/controllers/filter_planned_crops_controller.js
@@ -4,24 +4,24 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["season", "crop"]
   connect() {
-    hideAll(cropTargets)
+    this.cropTargets.forEach((target) => {
+      target.classList.add("d-none")
+    });
   };
 
   filterBySeason(event) {
-    hideAll(cropTargets)
-    let season = this.seasonTarget.value;
-    console.log(season)
     this.cropTargets.forEach((target) => {
-      console.log(target.getAttribute('value'))
+      target.classList.add("d-none")
+    });
+    let season = this.seasonTarget.value;
+    // console.log(season)
+    this.cropTargets.forEach((target) => {
+      // console.log(target.getAttribute('value'))
       if (target.getAttribute('value') === season) {
         target.classList.remove("d-none")
       };
     });
   }
 
-  hideAll(targets) {
-    this.targets.forEach((target) => {
-      target.classList.add("d-none")
-    });
-  }
+
 }

--- a/app/javascript/controllers/filter_planned_crops_controller.js
+++ b/app/javascript/controllers/filter_planned_crops_controller.js
@@ -4,15 +4,11 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["season", "crop"]
   connect() {
-    // this.cropTargets.forEach((target) => {
-    //   target.classList.add("d-none")
-    // });
+    hideAll(cropTargets)
   };
 
   filterBySeason(event) {
-    this.cropTargets.forEach((target) => {
-      target.classList.add("d-none")
-    });
+    hideAll(cropTargets)
     let season = this.seasonTarget.value;
     console.log(season)
     this.cropTargets.forEach((target) => {
@@ -20,6 +16,12 @@ export default class extends Controller {
       if (target.getAttribute('value') === season) {
         target.classList.remove("d-none")
       };
+    });
+  }
+
+  hideAll(targets) {
+    this.targets.forEach((target) => {
+      target.classList.add("d-none")
     });
   }
 }

--- a/app/javascript/controllers/filter_planned_crops_controller.js
+++ b/app/javascript/controllers/filter_planned_crops_controller.js
@@ -1,27 +1,25 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="filter-planned-crops"
 export default class extends Controller {
   static targets = ["season", "crop"]
+
   connect() {
-    this.cropTargets.forEach((target) => {
-      target.classList.add("d-none")
-    });
+    this.hideAll(this.cropTargets);
   };
 
   filterBySeason(event) {
-    this.cropTargets.forEach((target) => {
-      target.classList.add("d-none")
-    });
+    this.hideAll(this.cropTargets);
     let season = this.seasonTarget.value;
-    // console.log(season)
     this.cropTargets.forEach((target) => {
-      // console.log(target.getAttribute('value'))
       if (target.getAttribute('value') === season) {
         target.classList.remove("d-none")
       };
     });
   }
 
-
+  hideAll(targets) {
+    targets.forEach((target) => {
+      target.classList.add("d-none")
+    });
+  }
 }

--- a/app/views/crops/_crop_modal.html.erb
+++ b/app/views/crops/_crop_modal.html.erb
@@ -22,16 +22,20 @@
     </div>
 
     <!-- ------------------------------- emoji modal button  -------------------------------- -->
-    <h1 data-filter-planned-crops-target="crop" id="<%= bed.id %>" class="mb-3 ps-10" value="<%= season %>">
+    <h1 id="<%= bed.id %>" class="mb-3 ps-10" value="<%= season %>">
       <a style="text-decoration: none;" data-bs-toggle="modal" href="#cropmodal<%= crop.id %>" role="button"><%= crop.emoji %></a>
     </h1>
   </div>
 </div>
 
-<%# ------  history page behaviour -------- %>
+<%# ------  plans page emoji modal button -------- %>
+<% elsif current_page?(plans_path) %>
+  <h1 id="<%= bed.id %>" data-filter-planned-crops-target="crop" class="m-2" value="<%= season %>">
+    <a style="text-decoration: none;" data-bs-toggle="modal" href="#cropmodal<%= crop.id %>" role="button"><%= crop.emoji %></a>
+  </h1>
+
+<%# ------  history page emoji modal button -------- %>
 <% else %>
-  <!-- ------------------------------- emoji modal button  -------------------------------- -->
-  <%# removed the following to get working for demo day: data-filter-planned-crops-target="crop" %>
   <h1 id="<%= bed.id %>" class="m-2" value="<%= season %>">
     <a style="text-decoration: none;" data-bs-toggle="modal" href="#cropmodal<%= crop.id %>" role="button"><%= crop.emoji %></a>
   </h1>


### PR DESCRIPTION
Issue:

- all upcoming crops displayed by default on plans page

Fix:
- conditionally set emoji modal to be a data target when current page is plans_path