### PR TITLE
edit garden icon updated 

### DIFF
--- a/app/views/gardens/_garden.html.erb
+++ b/app/views/gardens/_garden.html.erb
@@ -44,8 +44,7 @@
 
           <%# ------------- Edit Button ------------- %>
           <li>
-            <a class="btn btn-light" data-bs-toggle="modal" href="#editgardenmodal<%= garden.id %>" role="button"><i class="fa-solid fa-binoculars"></i> Edit Garden</a>
-            <%# <%= link_to ('<i class="fa-solid fa-binoculars"></i>').html_safe + " Edit Garden", edit_garden_path(garden), class: "btn btn-light" %>
+            <a class="btn btn-light" data-bs-toggle="modal" href="#editgardenmodal<%= garden.id %>" role="button"><i class="fa-solid fa-pencil"></i> Edit Garden</a>
           </li>
 
           <%# ------------- Delete Garden Button ------------- %>


### PR DESCRIPTION
Icon got updated in error, reverted back to a pencil

Issue:
<img width="247" alt="image" src="https://user-images.githubusercontent.com/68765634/219006043-139e5bd5-4cb3-4fa7-9ca2-ed2401a38ca1.png">
